### PR TITLE
🔧 build: Update CXX Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,17 +5,16 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-ADD_COMPILE_OPTIONS(-std=c++14)
-ADD_COMPILE_OPTIONS(-std=c++14)
-set(CMAKE_CXX_FLAGS "-std=c++14 -O3")
+ADD_COMPILE_OPTIONS(-std=c++17)
+set(CMAKE_CXX_FLAGS "-std=c++17 -O3")
 
 add_definitions(-DROOT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fexceptions")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pthread -std=c++0x -std=c++14 -fexceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -pthread -fexceptions")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")


### PR DESCRIPTION
While compiling with some toolchains(CMake 3.30.3, GCC 14.2.0 e.g.), the C++ version defined in `CMakeLists.txt` may cause some problems.

[full error log](https://github.com/user-attachments/files/19791406/error.log)

<details>

```log
[Processing: point_lio]                                         
--- stderr: point_lio                                           
In file included from /opt/ros/humble/include/rclcpp/rclcpp/callback_group.hpp:24,
                 from /opt/ros/humble/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor_options.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor.hpp:37,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors.hpp:21,
                 from /opt/ros/humble/include/rclcpp/rclcpp/rclcpp.hpp:155,
                 from /opt/ros/humble/include/pcl_conversions/pcl_conversions/pcl_conversions.h:43,
                 from /home/debian/pb2025_sentry_nav/point_lio/src/preprocess.h:1,
                 from /home/debian/pb2025_sentry_nav/point_lio/src/preprocess.cpp:1:
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:788:36: error: ‘variant’ in namespace ‘std’ does not name a template type
  788 |   using CallbackInfoVariant = std::variant<
      |                                    ^~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:788:31: note: ‘std::variant’ is only available from C++17 onwards
  788 |   using CallbackInfoVariant = std::variant<
      |                               ^~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:794:52: error: ‘CallbackInfoVariant’ has not been declared
  794 |   async_send_request_impl(const Request & request, CallbackInfoVariant value)
      |                                                    ^~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:808:8: error: ‘optional’ in namespace ‘std’ does not name a template type
  808 |   std::optional<CallbackInfoVariant>
      |        ^~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:808:3: note: ‘std::optional’ is only available from C++17 onwards
  808 |   std::optional<CallbackInfoVariant>
      |   ^~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:830:7: error: ‘CallbackInfoVariant’ was not declared in this scope
  830 |       CallbackInfoVariant>>
      |       ^~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:830:7: error: template argument 2 is invalid
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:830:26: error: template argument 2 is invalid
  830 |       CallbackInfoVariant>>
      |                          ^~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:830:26: error: template argument 5 is invalid
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp: In member function ‘void rclcpp::Client<ServiceT>::handle_response(std::shared_ptr<rmw_request_id_s>, std::shared_ptr<void>)’:
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:550:10: error: ‘optional’ is not a member of ‘std’
  550 |     std::optional<CallbackInfoVariant>
      |          ^~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:550:10: note: ‘std::optional’ is only available from C++17 onwards
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:550:19: error: ‘CallbackInfoVariant’ was not declared in this scope
  550 |     std::optional<CallbackInfoVariant>
      |                   ^~~~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:551:5: error: ‘optional_pending_request’ was not declared in this scope; did you mean ‘remove_pending_request’?
  551 |     optional_pending_request = this->get_and_erase_pending_request(request_header->sequence_number);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
      |     remove_pending_request
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:558:14: error: ‘holds_alternative’ is not a member of ‘std’
  558 |     if (std::holds_alternative<Promise>(value)) {
      |              ^~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:558:14: note: ‘std::holds_alternative’ is only available from C++17 onwards
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:558:39: error: expected primary-expression before ‘>’ token
  558 |     if (std::holds_alternative<Promise>(value)) {
      |                                       ^
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:561:21: error: ‘holds_alternative’ is not a member of ‘std’
  561 |     } else if (std::holds_alternative<CallbackTypeValueVariant>(value)) {
      |                     ^~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:561:21: note: ‘std::holds_alternative’ is only available from C++17 onwards
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:561:63: error: expected primary-expression before ‘>’ token
  561 |     } else if (std::holds_alternative<CallbackTypeValueVariant>(value)) {
      |                                                               ^
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:568:21: error: ‘holds_alternative’ is not a member of ‘std’
  568 |     } else if (std::holds_alternative<CallbackWithRequestTypeValueVariant>(value)) {
      |                     ^~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:568:21: note: ‘std::holds_alternative’ is only available from C++17 onwards

... similar error ...

/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:977:3: error: no type named ‘variant_type’ in ‘using rclcpp::AnySubscriptionCallback<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void> >::HelperT = struct rclcpp::detail::AnySubscriptionCallbackHelper<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void>, false>’ {aka ‘struct rclcpp::detail::AnySubscriptionCallbackHelper<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void>, false>’}
  977 |   get_variant()
      |   ^~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:983:3: error: no type named ‘variant_type’ in ‘using rclcpp::AnySubscriptionCallback<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void> >::HelperT = struct rclcpp::detail::AnySubscriptionCallbackHelper<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void>, false>’ {aka ‘struct rclcpp::detail::AnySubscriptionCallbackHelper<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void>, false>’}
  983 |   get_variant() const
      |   ^~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/any_subscription_callback.hpp:993:34: error: no type named ‘variant_type’ in ‘using rclcpp::AnySubscriptionCallback<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void> >::HelperT = struct rclcpp::detail::AnySubscriptionCallbackHelper<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void>, false>’ {aka ‘struct rclcpp::detail::AnySubscriptionCallbackHelper<sensor_msgs::msg::Imu_<std::allocator<void> >, std::allocator<void>, false>’}
  993 |   typename HelperT::variant_type callback_variant_;
      |                                  ^~~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/pointlio_mapping.dir/build.make:104: CMakeFiles/pointlio_mapping.dir/src/parameters.cpp.o] Error 1
gmake[2]: *** [CMakeFiles/pointlio_mapping.dir/build.make:90: CMakeFiles/pointlio_mapping.dir/src/li_initialization.cpp.o] Error 1
gmake[2]: *** [CMakeFiles/pointlio_mapping.dir/build.make:76: CMakeFiles/pointlio_mapping.dir/src/laserMapping.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/pointlio_mapping.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< point_lio [6min 46s, exited with code 2]
```

</details>

This PR upgrades CXX standard to C++17 in order to solve the problem above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to use the C++17 standard instead of C++14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->